### PR TITLE
[fix] 카피, 생성 UI 수정

### DIFF
--- a/src/components/CreateCampaign/CopyGroupModal/CopyGroupListForModal/index.tsx
+++ b/src/components/CreateCampaign/CopyGroupModal/CopyGroupListForModal/index.tsx
@@ -27,15 +27,19 @@ const CopyGroupListForModal = () => {
 
   useEffect(() => {
     if (groupList?.totalCopy) {
-      const page = Math.ceil(groupList?.totalCopy / listCount);
+      const page = Math.ceil(groupList?.totalCopyCount / listCount);
       setTotalPage(page);
     }
-  }, [groupList?.totalCopy]);
+  }, [groupList?.totalCopyCount, listCount]);
+
+  if (!groupList) {
+    return null;
+  }
 
   return (
     <div>
       <h4>카피 그룹 선택</h4>
-      <ListCount listCount={listCount} setListCount={setListCount} totalList={groupList?.totalCopy ?? 0} />
+      <ListCount listCount={listCount} setListCount={setListCount} totalList={groupList.totalCopyCount} setPageNum={setPageNum} />
       <ListCategory>
         <div>즐겨찾기</div>
         <div>
@@ -45,7 +49,7 @@ const CopyGroupListForModal = () => {
         <div>카피그룹명</div>
       </ListCategory>
       {groupList && <CopyGroupList copyList={groupList.groupList} onClick={onClickGroup} />}
-      {totalPage > 1 && <Pagination totalPage={totalPage} setPageNum={setPageNum} pageNum={pageNum} />}
+      {groupList?.totalCopy > 1 && <Pagination totalPage={totalPage} setPageNum={setPageNum} pageNum={pageNum} />}
     </div>
   );
 };

--- a/src/components/CreateCampaign/CopyGroupModal/MessageListForModal/index.tsx
+++ b/src/components/CreateCampaign/CopyGroupModal/MessageListForModal/index.tsx
@@ -94,13 +94,13 @@ const Sticky = styled.div`
 
 const MessageContainer = styled.div`
   gap: 10px;
-  margin-bottom: 30px;
+  margin-bottom: 40px;
   position: relative;
 `;
 
 const Message = styled.div`
   padding: 15px;
-  background-color: ${({ theme }) => theme.colors.blue20};
+  background-color: ${({ theme }) => theme.colors.white};
   border: 1px solid #bebebe;
   border-radius: 30px;
   height: 120px;

--- a/src/components/CreateCampaign/CreateCampaignCondition/MessageSetting/MessageSetting.styles.ts
+++ b/src/components/CreateCampaign/CreateCampaignCondition/MessageSetting/MessageSetting.styles.ts
@@ -4,6 +4,7 @@ export const Gap = styled.div`
   display: flex;
   flex-direction: column;
   gap: 50px;
+  margin-bottom: 50px;
 `;
 
 export const Title = styled.div`

--- a/src/components/CreateCampaign/CreateCampaignCondition/MessageSetting/MessageSetting.styles.ts
+++ b/src/components/CreateCampaign/CreateCampaignCondition/MessageSetting/MessageSetting.styles.ts
@@ -28,20 +28,18 @@ export const Desc = styled.div`
 export const RadioInput = styled.div`
   font-size: 20px;
   display: flex;
+  align-items: center;
   gap: 10px;
-  line-height: 30px;
   margin-bottom: 6px;
+  white-space: nowrap;
   input {
     min-width: 16px;
     min-height: 16px;
-
     :checked {
       background-color: black;
     }
   }
-  label {
-    white-space: nowrap;
-  }
+
   span {
     color: ${({ theme }) => theme.colors.gray50};
     font-size: 16px;

--- a/src/components/CreateCampaign/CreateCampaignCondition/SelectCopy/index.tsx
+++ b/src/components/CreateCampaign/CreateCampaignCondition/SelectCopy/index.tsx
@@ -47,7 +47,7 @@ const SelectCopy = () => {
       </S.FlexBox>
       <MessageContainer />
       <S.Title>
-        메시지 발송 URL
+        발송 URL
         <span>*</span>
       </S.Title>
       <S.FlexBox>

--- a/src/components/CreateCampaign/CustomerGroupModal/index.tsx
+++ b/src/components/CreateCampaign/CustomerGroupModal/index.tsx
@@ -62,7 +62,7 @@ const CustomerGroupModal = ({ isOpen, handler }: CustomerGroupModalProps) => {
       <Modal.Header onClick={handler}>고객 그룹 불러오기</Modal.Header>
       <Modal.Body>
         <h4>고객 그룹 선택</h4>
-        <ListCount listCount={listCount} setListCount={setListCount} totalList={groupList?.totalGroupPage ?? 0} />
+        <ListCount listCount={listCount} setListCount={setListCount} totalList={groupList?.totalGroupPage ?? 0} setPageNum={setPageNum} />
         <ListCategory>
           <div>즐겨찾기</div>
           <div>

--- a/src/components/CreateCampaign/Header/index.tsx
+++ b/src/components/CreateCampaign/Header/index.tsx
@@ -7,17 +7,23 @@ import { POST_SVG } from '../../../assets/Post';
 import useCreateCampaignMutation from '../../../quries/Campaign/useCreateCampaignMutation';
 import { campaignConditionState } from '../../../store/campaignConditionState';
 import Button from '../../common/Button';
+import CampaignSubmitModal from '../SubmitModal';
 import * as S from './Header.styles';
 
 const Header = () => {
   const [condition, setCondition] = useRecoilState(campaignConditionState);
+  const [showSubmitModal, setShowSubmitModal] = useState(false);
   const [title, setTitle] = useState('새 캠페인' + `${dayjs().format('YYMMDD')}`);
   const [editMode, setEditMode] = useState(false);
   const navigate = useNavigate();
 
-  const { mutate: createMutate } = useCreateCampaignMutation();
+  const { mutate: createMutate } = useCreateCampaignMutation(setShowSubmitModal);
   const handleEditMode = () => {
     setEditMode((prev) => !prev);
+  };
+
+  const handleSubmitModal = () => {
+    setShowSubmitModal((prev) => !prev);
   };
 
   const handleTitleInput = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -54,27 +60,30 @@ const Header = () => {
   };
 
   return (
-    <S.Fixed>
-      <S.Flex>
-        <S.LeftChevron onClick={goBack}>{CHEVRON.left}</S.LeftChevron>
+    <>
+      <S.Fixed>
         <S.Flex>
-          {!editMode ? (
-            <>
-              <S.Title>{condition.campaignName}</S.Title>
-              <S.SVG onClick={handleEditMode}>{POST_SVG.edit}</S.SVG>
-            </>
-          ) : (
-            <>
-              <S.TitleInput value={title} onChange={(e) => handleTitleInput(e)} />
-              <Button buttonColor="blue" title="저장" buttonSize="buttonS" onButtonClick={onSaveCampaignName} />
-            </>
-          )}
+          <S.LeftChevron onClick={goBack}>{CHEVRON.left}</S.LeftChevron>
+          <S.Flex>
+            {!editMode ? (
+              <>
+                <S.Title>{condition.campaignName}</S.Title>
+                <S.SVG onClick={handleEditMode}>{POST_SVG.edit}</S.SVG>
+              </>
+            ) : (
+              <>
+                <S.TitleInput value={title} onChange={(e) => handleTitleInput(e)} />
+                <Button buttonColor="blue" title="저장" buttonSize="buttonS" onButtonClick={onSaveCampaignName} />
+              </>
+            )}
+          </S.Flex>
         </S.Flex>
-      </S.Flex>
-      <div>
-        <Button title="캠페인 실행" buttonColor="blue" buttonSize="buttonM" isDisabled={isDisabledSumbit()} onButtonClick={onSubmit} />
-      </div>
-    </S.Fixed>
+        <div>
+          <Button title="캠페인 실행" buttonColor="blue" buttonSize="buttonM" isDisabled={isDisabledSumbit()} onButtonClick={onSubmit} />
+        </div>
+      </S.Fixed>
+      <CampaignSubmitModal isOpen={showSubmitModal} handleModal={handleSubmitModal} />
+    </>
   );
 };
 

--- a/src/components/CreateCampaign/MessageList/MessageList.stlyes.ts
+++ b/src/components/CreateCampaign/MessageList/MessageList.stlyes.ts
@@ -4,7 +4,7 @@ export const Layout = styled.div`
   padding: 50px;
   display: flex;
   justify-content: center;
-  gap: 120px;
+  gap: 30px;
   padding: 30px;
   height: 100%;
   background-color: ${({ theme }) => theme.colors.blue20};

--- a/src/components/CreateCampaign/MessageList/index.tsx
+++ b/src/components/CreateCampaign/MessageList/index.tsx
@@ -11,12 +11,12 @@ const MessageList = () => {
   const memberB = Math.ceil(condition.customerCnt / 2);
 
   return (
-    <>
+    <div>
       <S.Layout>
         <CampaignMessage type="A" member={memberA} initMessage={condition.messageA} />
         {condition.abTest && <CampaignMessage type="B" member={memberB} initMessage={condition.messageB} />}
       </S.Layout>
-    </>
+    </div>
   );
 };
 

--- a/src/components/CreateCampaign/SubmitModal/index.tsx
+++ b/src/components/CreateCampaign/SubmitModal/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '../../common/Button';
+import Modal from '../../common/Modal';
+
+interface CampaignSubmitModalProps {
+  isOpen: boolean;
+  handleModal: () => void;
+}
+
+const CampaignSubmitModal = ({ isOpen, handleModal }: CampaignSubmitModalProps) => {
+  const navigate = useNavigate();
+
+  const onClickConfirm = () => {
+    navigate('/campaign');
+  };
+  return (
+    <Modal.Frame isOpen={isOpen} onClick={handleModal} height="150px">
+      <Modal.Body>캠페인이 생성되었습니다.</Modal.Body>
+      <Modal.Footer>
+        <Button buttonColor="blue" title="확인" onButtonClick={onClickConfirm} buttonSize="buttonS" />
+      </Modal.Footer>
+    </Modal.Frame>
+  );
+};
+
+export default CampaignSubmitModal;

--- a/src/components/CreateCopy/CreateCopyCondition/CreateCopyCondition.styles.ts
+++ b/src/components/CreateCopy/CreateCopyCondition/CreateCopyCondition.styles.ts
@@ -29,9 +29,11 @@ export const CopyType = styled.button<CopyTypeProps>`
   cursor: pointer;
   width: 74px;
   height: 42px;
-  border: 1px solid #e1e1e1;
+  border: 1px solid;
+  border-color: ${(props) => (props.isSelected ? props.theme.colors.blue30 : props.theme.colors.gray30)};
   border-radius: 10px;
-  background-color: ${(props) => (props.isSelected ? '#e1e1e1' : 'white')};
+  color: ${(props) => (props.isSelected ? props.theme.colors.blue30 : props.theme.colors.gray50)};
+  background-color: ${(props) => (props.isSelected ? props.theme.colors.blue20 : props.theme.colors.blue10)};
 `;
 
 export const DropDownBox = styled.div`

--- a/src/components/CreateCopy/CreateCopyCondition/index.tsx
+++ b/src/components/CreateCopy/CreateCopyCondition/index.tsx
@@ -120,7 +120,7 @@ const CreateCondition = ({ condition, conditionDispatch }: CreatConditionProps) 
         onChange={(e) => onChangeKeywrod(e, 30)}
         onKeyUp={addKeyword}
         value={keyword}
-        placeholder="키워드를 입력해 주세요. 최대 8개까지 등록 가능해요."
+        placeholder="키워드는 콤마로 구분이 아닌 엔터로 적용해주세요. 최대 8개까지 등록 가능해요."
         disabled={condition.keyword.length === 8}
       />
       <S.KeywordContainer>
@@ -132,7 +132,10 @@ const CreateCondition = ({ condition, conditionDispatch }: CreatConditionProps) 
             </S.KeywordTag>
           ))}
       </S.KeywordContainer>
-      <S.Label>유형</S.Label>
+      <S.Label>
+        유형
+        <span>*</span>
+      </S.Label>
       <S.CopyTypeContainer>
         {COPY_TYPE.map((type) => (
           <S.CopyType isSelected={isSelected(type.title)} key={type.title} onClick={() => handleType(type.title)}>

--- a/src/components/CreateCopy/EditModal/index.tsx
+++ b/src/components/CreateCopy/EditModal/index.tsx
@@ -19,7 +19,7 @@ const EditWarningModal = ({ showEditWarnModal, handleEditWarnModal, setIsEditMod
   };
 
   return (
-    <Modal.Frame height="80px" isOpen={showEditWarnModal} onClick={handleEditWarnModal}>
+    <Modal.Frame height="120px" isOpen={showEditWarnModal} onClick={handleEditWarnModal}>
       <Modal.Body>{COPY_MESSAGE.EDIT}</Modal.Body>
       <Modal.Footer>
         <Button title="취소" buttonColor="white" buttonSize="buttonS" onButtonClick={onClickNo} />

--- a/src/components/DetailCopy/CopyDetails/CopyDetail.stlyes.ts
+++ b/src/components/DetailCopy/CopyDetails/CopyDetail.stlyes.ts
@@ -17,9 +17,20 @@ export const TextBox = styled.div`
   gap: 10px;
 `;
 
+export const KeywordWrapper = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
 export const Keyword = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 12px;
+  height: 42px;
+  border: 1px solid #e1e1e1;
   border-radius: 10px;
-  padding: 8px;
   background-color: ${({ theme }) => theme.colors.gray20};
 `;
 
@@ -34,7 +45,6 @@ interface CopyTypeProps {
 }
 
 export const CopyType = styled.button<CopyTypeProps>`
-  cursor: pointer;
   width: 74px;
   height: 42px;
   border: 1px solid #e1e1e1;

--- a/src/components/DetailCopy/CopyDetails/index.tsx
+++ b/src/components/DetailCopy/CopyDetails/index.tsx
@@ -40,6 +40,8 @@ const CopyDetails = () => {
     createCopytMutate(copyDetail as CopyDetailResult);
   };
 
+  console.log(copyDetail);
+
   return (
     <div>
       {isLoading && <Loading />}
@@ -54,11 +56,11 @@ const CopyDetails = () => {
         <span>{copyDetail?.productName}</span>
       </S.TextBox>
       <S.Label>필수로 포함할 키워드</S.Label>
-      <S.TextBox>
+      <S.KeywordWrapper>
         {copyDetail?.keyword?.split(',').map((keyword) => (
           <S.Keyword key={keyword}>{keyword}</S.Keyword>
         ))}
-      </S.TextBox>
+      </S.KeywordWrapper>
       <S.Label>유형</S.Label>
       <S.CopyTypeContainer>
         {COPY_TYPE.map((type) => (

--- a/src/components/common/DropDown/DropDown.styles.ts
+++ b/src/components/common/DropDown/DropDown.styles.ts
@@ -32,3 +32,15 @@ export const Base = styled.div<PaddingProps>`
   display: flex;
   justify-content: space-between;
 `;
+
+export const Chevron = styled.div`
+  width: 12px;
+`;
+
+interface ItemProps {
+  isSelected: boolean;
+}
+
+export const Item = styled.div<ItemProps>`
+  color: ${(props) => (props.isSelected ? props.theme.colors.red : props.theme.colors.gray50)};
+`;

--- a/src/components/common/DropDown/index.tsx
+++ b/src/components/common/DropDown/index.tsx
@@ -10,16 +10,20 @@ interface DorpDownProps {
 }
 
 const DropDwown = ({ list, base, handler, padding = '10px' }: DorpDownProps) => {
+  const isSelected = (item: number | string) => {
+    return base === item;
+  };
+
   return (
     <>
       <S.Container>
         <S.Base onClick={() => handler(base)} padding={padding}>
           <div>{base}</div>
-          <div>{CHEVRON.up}</div>
+          <S.Chevron>{CHEVRON.up}</S.Chevron>
         </S.Base>
         {list.map((item) => (
           <S.ListItem key={item} onClick={() => handler(item)} padding={padding}>
-            {item}
+            <S.Item isSelected={isSelected(item)}>{item}</S.Item>
           </S.ListItem>
         ))}
       </S.Container>

--- a/src/components/common/ListCount/index.tsx
+++ b/src/components/common/ListCount/index.tsx
@@ -9,9 +9,10 @@ interface ListCountProps {
   listCount: number;
   setListCount: Dispatch<SetStateAction<number>>;
   totalList: number;
+  setPageNum: Dispatch<SetStateAction<number>>;
 }
 
-const ListCount = ({ listCount, setListCount, totalList }: ListCountProps) => {
+const ListCount = ({ listCount, setListCount, totalList, setPageNum }: ListCountProps) => {
   const [showCountDropDown, setShowCountDropDown] = useState(false);
 
   const handleCountDropDown = () => {
@@ -19,6 +20,7 @@ const ListCount = ({ listCount, setListCount, totalList }: ListCountProps) => {
   };
 
   const handleCount = (count: number) => {
+    setPageNum(0);
     setListCount(count);
     handleCountDropDown();
   };

--- a/src/components/common/Modal/Modal.styles.ts
+++ b/src/components/common/Modal/Modal.styles.ts
@@ -46,14 +46,14 @@ export const ModalHeader = styled.div`
 
 export const ModalBody = styled.div`
   white-space: pre-wrap;
-  height: 80%;
+  height: 70%;
   overflow: auto;
 `;
 
 export const ModalFooter = styled.div`
   padding-top: 20px;
   width: 100%;
-  height: 20%;
+  height: 30%;
   display: flex;
   justify-content: flex-end;
   gap: 10px;

--- a/src/components/common/Modal/Modal.styles.ts
+++ b/src/components/common/Modal/Modal.styles.ts
@@ -44,6 +44,10 @@ export const ModalHeader = styled.div`
   }
 `;
 
+export const Hr = styled.hr`
+  margin: 0;
+`;
+
 export const ModalBody = styled.div`
   white-space: pre-wrap;
   height: 70%;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -47,7 +47,7 @@ const ModalHeader = ({ children, onClick }: ModalHeaderProps) => {
         <h2>{children}</h2>
         <div onClick={onClick}>{SVG.closeButton}</div>
       </S.ModalHeader>
-      <hr />
+      <S.Hr />
     </>
   );
 };

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -27,7 +27,7 @@ const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  padding: 4.25rem 6.125rem;
+  padding: 4.25rem 4.25rem;
 `;
 
 const Content = styled.div`

--- a/src/pages/CampaignGroups.tsx
+++ b/src/pages/CampaignGroups.tsx
@@ -41,7 +41,7 @@ const CapaignGroups = () => {
       >
         캠페인 리스트
       </PageHeader>
-      <ListCount listCount={listCount} setListCount={setListCount} totalList={campaignData?.totalCampaignCount ?? 0} />
+      <ListCount listCount={listCount} setListCount={setListCount} totalList={campaignData?.totalCampaignCount ?? 0} setPageNum={setPageNum} />
       <ListCategory>
         <div>즐겨찾기</div>
         <div>메세지 유형</div>

--- a/src/pages/CopyGroups.tsx
+++ b/src/pages/CopyGroups.tsx
@@ -40,7 +40,7 @@ const CopyGroups = () => {
       >
         카피그룹 리스트
       </PageHeader>
-      <ListCount listCount={listCount} setListCount={setListCount} totalList={groupList?.totalCopyCount ?? 0} />
+      <ListCount listCount={listCount} setListCount={setListCount} totalList={groupList?.totalCopyCount ?? 0} setPageNum={setPageNum} />
       <ListCategory>
         <div>즐겨찾기</div>
         <div>생성일</div>

--- a/src/quries/Campaign/useCreateCampaignMutation.ts
+++ b/src/quries/Campaign/useCreateCampaignMutation.ts
@@ -1,13 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
+import { Dispatch, SetStateAction } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createCamapign } from '../../api/Campaign';
 
-const useCreateCampaignMutation = () => {
-  const navigate = useNavigate();
-
+const useCreateCampaignMutation = (setShowSubmitModal: Dispatch<SetStateAction<boolean>>) => {
   return useMutation(createCamapign, {
     onSuccess: () => {
-      navigate('/campaign');
+      setShowSubmitModal(true);
     },
   });
 };

--- a/src/store/campaignConditionState.ts
+++ b/src/store/campaignConditionState.ts
@@ -31,7 +31,7 @@ export const campaignConditionState = atom<CampignConditionInit>({
     copyGroupName: '',
     abTest: true,
     messageType: 'LMS',
-    sendType: 'COMM',
+    sendType: 'AD',
     sentCycle: '일회성 발송',
     sendingDate: tommrrow.toString(),
     sendURL: '',


### PR DESCRIPTION
## 👀 개요

<!--

- Closes #이슈
- 간단한 설명

-->

## 📋 PR 유형

<!--

어떤 작업을 했는지 [x] 로 체크해주세요

-->

- [ ] 기능 추가
- [x] 기능 개선
- [ ] 기능 삭제
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 기타
<!-- - [x] 기타: style convention lint configuration (우측에 설명기입) -->

<br />

## 🧑‍💻 구현 디테일 및 화면

<!--

작업한 내용을 이해하기 좋게 작성해주세요.
프론트엔드 작업의 경우 스크린샷이나 녹화가 있으면 좋아요.

-->

- 모달 바디와 푸터 사이즈 각 70%,30% 으로 변경
- 드롭 다운 에서 선택된 아이템 빨간색으로 표시
- 카피그룹 유형 태그 색상 변경
- 카피 상세 페이지 키워드 전체 감싸던 박스 제거
- 캠페인 생성 발신유형 및 카피 선택 사이의 마진 추가
- 모달 hr태그 마진 제거 

<br />

## ✔️ 참고 사항 및 자료

<!-- 특이 사항이나 레퍼런스 링크가 있다면 작성해주세요. -->

-
